### PR TITLE
Add track volume controls

### DIFF
--- a/js/audio-engine.js
+++ b/js/audio-engine.js
@@ -10,6 +10,8 @@ class AudioEngine {
         this.isInitialized = false;
         this.sounds = {};
         this.masterGain = null;
+        this.trackGains = {};
+        this.trackNames = ['kick', 'snare', 'hihat', 'percussion', 'bass', 'lead', 'chord', 'effect'];
         this.analyser = null; // Added analyser node
         this.isPlaying = false;
         this.tempo = 120;
@@ -24,7 +26,15 @@ class AudioEngine {
         try {
             this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
             this.masterGain = this.audioContext.createGain();
-            
+
+            // Create per-track gain nodes
+            this.trackNames.forEach(name => {
+                const gain = this.audioContext.createGain();
+                gain.gain.value = 1;
+                gain.connect(this.masterGain);
+                this.trackGains[name] = gain;
+            });
+
             // Create analyser node for waveform visualization
             this.analyser = this.audioContext.createAnalyser();
             this.analyser.fftSize = 2048; // Large enough for detailed waveform
@@ -77,7 +87,7 @@ class AudioEngine {
             gainNode.gain.exponentialRampToValueAtTime(0.001, time + 0.3);
             
             osc.connect(gainNode);
-            gainNode.connect(this.masterGain);
+            gainNode.connect(this.trackGains.kick);
             
             osc.start(time);
             osc.stop(time + 0.3);
@@ -114,10 +124,10 @@ class AudioEngine {
             
             // Connect everything
             noise.connect(noiseGain);
-            noiseGain.connect(this.masterGain);
-            
+            noiseGain.connect(this.trackGains.snare);
+
             osc.connect(oscGain);
-            oscGain.connect(this.masterGain);
+            oscGain.connect(this.trackGains.snare);
             
             noise.start(time);
             osc.start(time);
@@ -149,7 +159,7 @@ class AudioEngine {
             
             noise.connect(noiseFilter);
             noiseFilter.connect(noiseGain);
-            noiseGain.connect(this.masterGain);
+            noiseGain.connect(this.trackGains.hihat);
             
             noise.start(time);
         };
@@ -169,7 +179,7 @@ class AudioEngine {
             gainNode.gain.exponentialRampToValueAtTime(0.01, time + 0.2);
             
             osc.connect(gainNode);
-            gainNode.connect(this.masterGain);
+            gainNode.connect(this.trackGains.percussion);
             
             osc.start(time);
             osc.stop(time + 0.2);
@@ -195,7 +205,7 @@ class AudioEngine {
             
             osc.connect(filter);
             filter.connect(gainNode);
-            gainNode.connect(this.masterGain);
+            gainNode.connect(this.trackGains.bass);
             
             osc.start(time);
             osc.stop(time + 0.4);
@@ -215,7 +225,7 @@ class AudioEngine {
             gainNode.gain.exponentialRampToValueAtTime(0.01, time + 0.3);
             
             osc.connect(gainNode);
-            gainNode.connect(this.masterGain);
+            gainNode.connect(this.trackGains.lead);
             
             osc.start(time);
             osc.stop(time + 0.3);
@@ -239,7 +249,7 @@ class AudioEngine {
                 gainNode.gain.exponentialRampToValueAtTime(0.01, time + 0.5);
                 
                 osc.connect(gainNode);
-                gainNode.connect(this.masterGain);
+                gainNode.connect(this.trackGains.chord);
                 
                 oscillators.push(osc);
                 
@@ -263,7 +273,7 @@ class AudioEngine {
             gainNode.gain.exponentialRampToValueAtTime(0.01, time + 0.3);
             
             osc.connect(gainNode);
-            gainNode.connect(this.masterGain);
+            gainNode.connect(this.trackGains.effect);
             
             osc.start(time);
             osc.stop(time + 0.3);
@@ -313,6 +323,14 @@ class AudioEngine {
     setTempo(bpm) {
         this.tempo = bpm;
         console.log(`Tempo set to ${bpm} BPM`);
+    }
+
+    // Set volume for a specific track (0.0 to 1.0)
+    setTrackVolume(trackName, volume) {
+        if (this.trackGains[trackName]) {
+            this.trackGains[trackName].gain.value = volume;
+            console.log(`Volume for ${trackName} set to ${volume}`);
+        }
     }
 }
 

--- a/js/main.js
+++ b/js/main.js
@@ -6,10 +6,13 @@
 document.addEventListener('DOMContentLoaded', function() {
     // Initialize the sequencer grid
     initializeSequencerGrid();
-    
+
     // Initialize beat indicators
     initializeBeatIndicators();
-    
+
+    // Create track volume controls
+    initializeTrackControls();
+
     // Initialize the audio engine, sequencer, and UI controller
     initializeApplication();
 });
@@ -57,6 +60,39 @@ function initializeBeatIndicators() {
     }
     
     console.log('Beat indicators initialized');
+}
+
+function initializeTrackControls() {
+    const container = document.querySelector('.track-controls-container');
+    if (!container) return;
+
+    sequencer.tracks.forEach(track => {
+        const wrapper = document.createElement('div');
+        wrapper.className = 'track-control';
+
+        const label = document.createElement('label');
+        label.textContent = `${track.name} Volume`;
+        label.setAttribute('for', `volume-${track.id}`);
+
+        const slider = document.createElement('input');
+        slider.type = 'range';
+        slider.min = '0';
+        slider.max = '1';
+        slider.step = '0.01';
+        slider.value = '1';
+        slider.id = `volume-${track.id}`;
+
+        slider.addEventListener('input', (e) => {
+            const volume = parseFloat(e.target.value);
+            audioEngine.setTrackVolume(track.id, volume);
+        });
+
+        wrapper.appendChild(label);
+        wrapper.appendChild(slider);
+        container.appendChild(wrapper);
+    });
+
+    console.log('Track controls initialized');
 }
 
 function initializeApplication() {

--- a/styles.css
+++ b/styles.css
@@ -497,6 +497,25 @@ input[type="range"]::-moz-range-thumb {
     gap: 20px;
 }
 
+.track-control {
+    display: flex;
+    flex-direction: column;
+    background-color: var(--surface-color);
+    padding: 10px;
+    border-radius: 4px;
+    border: var(--pixel-border);
+}
+
+.track-control label {
+    margin-bottom: 8px;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+}
+
+.track-control input[type="range"] {
+    width: 100%;
+}
+
 /* Footer */
 footer {
     text-align: center;


### PR DESCRIPTION
## Summary
- add per-track gain nodes to audio engine
- wire up track volume sliders in the UI
- style the new track control elements

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68424b3dc72c832ba7f48d1f60d2cdf3